### PR TITLE
Implement CRChangeRecordLoader

### DIFF
--- a/packages/ChangesReloaded-Core.package/CRChangeRecordLoader.class/instance/addChangeRecord..st
+++ b/packages/ChangesReloaded-Core.package/CRChangeRecordLoader.class/instance/addChangeRecord..st
@@ -1,0 +1,4 @@
+collection-operations
+addChangeRecord: aChangeRecord
+
+	self changeRecords add: aChangeRecord

--- a/packages/ChangesReloaded-Core.package/CRChangeRecordLoader.class/instance/changeRecords..st
+++ b/packages/ChangesReloaded-Core.package/CRChangeRecordLoader.class/instance/changeRecords..st
@@ -1,0 +1,4 @@
+accessing
+changeRecords: anOrderedCollection
+
+	changeRecords := anOrderedCollection

--- a/packages/ChangesReloaded-Core.package/CRChangeRecordLoader.class/instance/changeRecords.st
+++ b/packages/ChangesReloaded-Core.package/CRChangeRecordLoader.class/instance/changeRecords.st
@@ -1,0 +1,4 @@
+accessing
+changeRecords
+
+	^ changeRecords

--- a/packages/ChangesReloaded-Core.package/CRChangeRecordLoader.class/instance/clearChangeRecords.st
+++ b/packages/ChangesReloaded-Core.package/CRChangeRecordLoader.class/instance/clearChangeRecords.st
@@ -1,0 +1,4 @@
+collection-operations
+clearChangeRecords
+
+	changeRecords := OrderedCollection new

--- a/packages/ChangesReloaded-Core.package/CRChangeRecordLoader.class/instance/file..st
+++ b/packages/ChangesReloaded-Core.package/CRChangeRecordLoader.class/instance/file..st
@@ -1,0 +1,4 @@
+accessing
+file: aMultiByteFileStream
+
+	file := aMultiByteFileStream

--- a/packages/ChangesReloaded-Core.package/CRChangeRecordLoader.class/instance/file.st
+++ b/packages/ChangesReloaded-Core.package/CRChangeRecordLoader.class/instance/file.st
@@ -1,0 +1,4 @@
+accessing
+file
+
+	^ file

--- a/packages/ChangesReloaded-Core.package/CRChangeRecordLoader.class/instance/initialize.st
+++ b/packages/ChangesReloaded-Core.package/CRChangeRecordLoader.class/instance/initialize.st
@@ -1,0 +1,5 @@
+initializing
+initialize
+
+	super initialize.
+	self clearChangeRecords

--- a/packages/ChangesReloaded-Core.package/CRChangeRecordLoader.class/instance/isAtBeginningOfChunk.st
+++ b/packages/ChangesReloaded-Core.package/CRChangeRecordLoader.class/instance/isAtBeginningOfChunk.st
@@ -1,0 +1,4 @@
+file-utils
+isAtBeginningOfChunk
+
+	^ self file atEnd or: [self file peek isSeparator not]

--- a/packages/ChangesReloaded-Core.package/CRChangeRecordLoader.class/instance/isCurrentChunkACategory.st
+++ b/packages/ChangesReloaded-Core.package/CRChangeRecordLoader.class/instance/isCurrentChunkACategory.st
@@ -1,0 +1,4 @@
+file-utils
+isCurrentChunkACategory
+
+	^ self file peekFor: $!

--- a/packages/ChangesReloaded-Core.package/CRChangeRecordLoader.class/instance/isNewline..st
+++ b/packages/ChangesReloaded-Core.package/CRChangeRecordLoader.class/instance/isNewline..st
@@ -1,0 +1,4 @@
+file-utils
+isNewline: aCharacter
+
+	^ aCharacter = Character cr or: [aCharacter = Character lf]

--- a/packages/ChangesReloaded-Core.package/CRChangeRecordLoader.class/instance/loadCategory.class.meta.stamp..st
+++ b/packages/ChangesReloaded-Core.package/CRChangeRecordLoader.class/instance/loadCategory.class.meta.stamp..st
@@ -1,0 +1,15 @@
+loading
+loadCategory: category class: class meta: meta stamp: stamp
+	| itemPosition method selector |
+	[itemPosition := file position.
+	method := file nextChunk.
+	file skipStyleChunk.
+	method size > 0] "done when double terminators"
+		whileTrue:
+		[self addItem: (ChangeRecord new file: file position: itemPosition type: #method
+							class: class category: category meta: meta stamp: stamp)
+			text: 'method: ' , class , (meta ifTrue: [' class '] ifFalse: [' '])
+				, ((selector := ((Smalltalk classNamed: class) ifNil: [Object]) newParser parseSelector: method) isNil
+					ifTrue: ['unparsableSelector']
+					ifFalse: [selector])
+				, (stamp isEmpty ifTrue: [''] ifFalse: ['; ' , stamp])]

--- a/packages/ChangesReloaded-Core.package/CRChangeRecordLoader.class/instance/loadCategory.st
+++ b/packages/ChangesReloaded-Core.package/CRChangeRecordLoader.class/instance/loadCategory.st
@@ -1,0 +1,46 @@
+loading
+loadCategory
+	"Load all change records within this group of chunks; method name is historical only"
+
+	| itemPosition item tokens stamp anIndex |
+	itemPosition := file position.
+	item := file nextChunk.
+
+	((item includesSubstring: 'commentStamp:')
+	or: [(item includesSubstring: 'methodsFor:')
+	or: [item endsWith: 'reorganize']]) ifFalse:
+		["Maybe a preamble, but not one we recognize; bail out with the preamble trick"
+		^ self addItem: (ChangeRecord new file: file position: itemPosition type: #preamble)
+				 text: ('preamble: ' , item contractTo: 50)].
+
+	tokens := Scanner new scanTokens: item.
+	tokens size >= 3 ifTrue:
+		[stamp := ''.
+		anIndex := tokens indexOf: #stamp: ifAbsent: [nil].
+		anIndex ifNotNil: [stamp := tokens at: (anIndex + 1)].
+
+		tokens second == #methodsFor:
+			ifTrue: [^ self scanCategory: tokens third class: tokens first
+							meta: false stamp: stamp].
+		tokens third == #methodsFor:
+			ifTrue: [^ self scanCategory: tokens fourth class: tokens first
+							meta: true stamp: stamp]].
+
+	tokens second == #commentStamp:
+		ifTrue:
+			[stamp := tokens third.
+			self addItem:
+					(ChangeRecord new file: file position: file position type: #classComment
+									class: tokens first category: nil meta: false stamp: stamp)
+					text: 'class comment for ' , tokens first, 
+						  (stamp isEmpty ifTrue: [''] ifFalse: ['; ' , stamp]).
+			file nextChunk.
+			^ file skipStyleChunk].
+
+	self assert: tokens last == #reorganize.
+	self addItem:
+		(ChangeRecord new
+			file: file position: file position type: #reorganize
+			class: tokens first category: nil meta: false stamp: stamp)
+		text: 'organization for ' , tokens first, (tokens second == #class ifTrue: [' class'] ifFalse: ['']).
+	file nextChunk

--- a/packages/ChangesReloaded-Core.package/CRChangeRecordLoader.class/instance/loadChangeRecord.st
+++ b/packages/ChangesReloaded-Core.package/CRChangeRecordLoader.class/instance/loadChangeRecord.st
@@ -1,0 +1,15 @@
+loading
+loadChangeRecord
+
+	| chunkPosition chunk |
+	chunkPosition := self file position.
+	chunk := self file nextChunk.
+	self file skipStyleChunk.
+
+	chunk size > 0 ifTrue: [
+		| type |
+		(chunk beginsWith: '----')
+			ifTrue: [type := #misc]
+			ifFalse: [type := #doIt].
+		self addChangeRecord: (ChangeRecord new
+			file: self file position: chunkPosition type: type)]

--- a/packages/ChangesReloaded-Core.package/CRChangeRecordLoader.class/instance/loadFrom.to.onProgress..st
+++ b/packages/ChangesReloaded-Core.package/CRChangeRecordLoader.class/instance/loadFrom.to.onProgress..st
@@ -1,0 +1,16 @@
+loading
+loadFrom: startPosition to: stopPosition onProgress: aBlock
+	
+	| prevChar |
+	self clearChangeRecords.
+	file position: startPosition.
+	[file position < stopPosition] whileTrue: [
+		| progress |
+		progress := (file position - startPosition) / (stopPosition - startPosition).
+		aBlock value: progress.
+		
+		[self isAtBeginningOfChunk] whileFalse: [prevChar := file next].
+
+		self isCurrentChunkACategory
+			ifTrue: [(self isNewline: prevChar) ifTrue: [self loadCategory]]
+			ifFalse: [self loadChangeRecord]]

--- a/packages/ChangesReloaded-Core.package/CRChangeRecordLoader.class/methodProperties.json
+++ b/packages/ChangesReloaded-Core.package/CRChangeRecordLoader.class/methodProperties.json
@@ -1,0 +1,18 @@
+{
+	"class" : {
+		 },
+	"instance" : {
+		"addChangeRecord:" : "mg 5/30/2020 14:22",
+		"changeRecords" : "mg 5/30/2020 13:59",
+		"changeRecords:" : "mg 5/30/2020 13:59",
+		"clearChangeRecords" : "mg 5/30/2020 14:02",
+		"file" : "mg 5/30/2020 13:59",
+		"file:" : "mg 5/30/2020 14:00",
+		"initialize" : "mg 5/30/2020 14:02",
+		"isAtBeginningOfChunk" : "mg 5/30/2020 14:07",
+		"isCurrentChunkACategory" : "mg 5/30/2020 14:10",
+		"isNewline:" : "mg 5/30/2020 14:13",
+		"loadCategory" : "mg 5/30/2020 14:30",
+		"loadCategory:class:meta:stamp:" : "mg 5/30/2020 14:36",
+		"loadChangeRecord" : "mg 5/30/2020 14:24",
+		"loadFrom:to:onProgress:" : "mg 5/30/2020 14:31" } }

--- a/packages/ChangesReloaded-Core.package/CRChangeRecordLoader.class/properties.json
+++ b/packages/ChangesReloaded-Core.package/CRChangeRecordLoader.class/properties.json
@@ -1,0 +1,15 @@
+{
+	"category" : "ChangesReloaded-Core",
+	"classinstvars" : [
+		 ],
+	"classvars" : [
+		 ],
+	"commentStamp" : "",
+	"instvars" : [
+		"file",
+		"changeRecords" ],
+	"name" : "CRChangeRecordLoader",
+	"pools" : [
+		 ],
+	"super" : "Object",
+	"type" : "normal" }


### PR DESCRIPTION
Merge #73 and #75 first
Closes: #71 

This is the new class that contains the loading functionality of the ChangeList. We plan to patch this into the Squeak image, so it should change its name (remove the prefix) and go into another package. The ChangeList should also be changed to use this class instead of doing the loading itself.